### PR TITLE
Add buildQueuedDuration to BuildEvent

### DIFF
--- a/src/main/java/org/gitlab4j/api/webhook/BuildEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/BuildEvent.java
@@ -25,6 +25,8 @@ public class BuildEvent extends AbstractEvent {
     private Date buildStarted_at;
     private Date buildFinished_at;
     private Float buildDuration;
+
+    private Float buildQueuedDuration;
     private Boolean buildAllowFailure;
     private String buildFailureReason;
     private Long projectId;
@@ -129,6 +131,14 @@ public class BuildEvent extends AbstractEvent {
 
     public void setBuildDuration(Float buildDuration) {
         this.buildDuration = buildDuration;
+    }
+
+    public Float getBuildQueuedDuration() {
+        return buildQueuedDuration;
+    }
+
+    public void setBuildQueuedDuration(Float buildQueuedDuration) {
+        this.buildQueuedDuration = buildQueuedDuration;
     }
 
     public Boolean getBuildAllowFailure() {


### PR DESCRIPTION
Fixing https://github.com/gitlab4j/gitlab4j-api/issues/780 issue.

To me, it seems valid and sending by gitlab (in my setup at least).